### PR TITLE
feat: add structured hoop_connections output, drop run_hoop and CLI provisioners

### DIFF
--- a/hoop.tf
+++ b/hoop.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -15,107 +15,57 @@ data "aws_secretsmanager_secret" "rds_managed" {
 locals {
   master_user_secret_name_arn = try(split(":", module.this.db_instance_master_user_secret_arn), [])
   master_user_secret_name     = length(local.master_user_secret_name_arn) - 1 >= 0 ? local.master_user_secret_name_arn[length(local.master_user_secret_name_arn) - 1] : ""
-  hoop_tags                   = length(try(var.settings.hoop.tags, [])) > 0 ? join(" ", [for v in var.settings.hoop.tags : "--tags \"${v}\""]) : ""
-  hoop_connection_postgres_managed = try(var.settings.hoop.enabled, false) && strcontains(var.settings.engine_type, "postgres") && try(var.settings.managed_password, false) ? (<<EOT
-hoop admin create connection ${local.db_identifier}-ow \
-  --agent ${var.settings.hoop.agent} \
-  --type database/postgres \
-  -e "HOST=${module.this.db_instance_address}" \
-  -e "PORT=${module.this.db_instance_port}" \
-  -e "USER=_aws:${data.aws_secretsmanager_secret.rds_managed[0].name}:username" \
-  -e "PASS=_aws:${data.aws_secretsmanager_secret.rds_managed[0].name}:password" \
-  -e "DB=${local.db_name}" \
-  -e "SSLMODE=prefer" \
-  --overwrite \
-  ${local.hoop_tags}
-EOT
-  ) : null
-  hoop_connection_postgres = try(var.settings.hoop.enabled, false) && strcontains(var.settings.engine_type, "postgres") && !try(var.settings.managed_password, false) ? (<<EOT
-hoop admin create connection ${local.db_identifier}-ow \
-  --agent ${var.settings.hoop.agent} \
-  --type database/postgres \
-  -e "HOST=_aws:${aws_secretsmanager_secret.rds[0].name}:host" \
-  -e "PORT=_aws:${aws_secretsmanager_secret.rds[0].name}:port" \
-  -e "USER=_aws:${aws_secretsmanager_secret.rds[0].name}:username" \
-  -e "PASS=_aws:${aws_secretsmanager_secret.rds[0].name}:password" \
-  -e "DB=_aws:${aws_secretsmanager_secret.rds[0].name}:dbname" \
-  -e "SSLMODE=prefer" \
-  --overwrite \
-  ${local.hoop_tags}
-EOT
-  ) : null
-  hoop_connection_mysql_managed = try(var.settings.hoop.enabled, false) && strcontains(var.settings.engine_type, "mysql") && try(var.settings.managed_password, false) ? (<<EOT
-hoop admin create connection ${local.db_identifier}-ow \
-  --agent ${var.settings.hoop.agent} \
-  --type database/mysql \
-  -e "HOST=_aws:${data.aws_secretsmanager_secret.rds_managed[0].name}:host" \
-  -e "PORT=_aws:${data.aws_secretsmanager_secret.rds_managed[0].name}:port" \
-  -e "USER=_aws:${data.aws_secretsmanager_secret.rds_managed[0].name}:username" \
-  -e "PASS=_aws:${data.aws_secretsmanager_secret.rds_managed[0].name}:password" \
-  -e "DB=_aws:${data.aws_secretsmanager_secret.rds_managed[0].name}:dbname" \
-  --overwrite \
-  ${local.hoop_tags}
-EOT
-  ) : null
-  hoop_connection_mysql = try(var.settings.hoop.enabled, false) && strcontains(var.settings.engine_type, "mysql") && !try(var.settings.managed_password, false) ? (<<EOT
-hoop admin create connection ${local.db_identifier}-ow \
-  --agent ${var.settings.hoop.agent} \
-  --type database/mysql \
-  -e "HOST=_aws:${aws_secretsmanager_secret.rds[0].name}:host" \
-  -e "PORT=_aws:${aws_secretsmanager_secret.rds[0].name}:port" \
-  -e "USER=_aws:${aws_secretsmanager_secret.rds[0].name}:username" \
-  -e "PASS=_aws:${aws_secretsmanager_secret.rds[0].name}:password" \
-  -e "DB=_aws:${aws_secretsmanager_secret.rds[0].name}:dbname" \
-  --overwrite \
-  ${local.hoop_tags}
-EOT
-  ) : null
+  hoop_enabled                = try(var.settings.hoop.enabled, false)
+  hoop_secret_prefix          = try(var.settings.hoop.community, true) ? "_aws" : "_envs/aws"
+  hoop_secret_sep             = try(var.settings.hoop.community, true) ? ":" : "#"
+  hoop_is_postgres            = strcontains(try(var.settings.engine_type, ""), "postgres")
+  hoop_is_managed             = try(var.settings.managed_password, false)
+  hoop_managed_secret_name    = try(data.aws_secretsmanager_secret.rds_managed[0].name, "")
+  hoop_unmanaged_secret_name  = try(aws_secretsmanager_secret.rds[0].name, "")
 }
 
-resource "null_resource" "hoop_connection_postgres_managed" {
-  count = local.hoop_connection_postgres_managed != null && var.run_hoop ? 1 : 0
-  provisioner "local-exec" {
-    command     = local.hoop_connection_postgres_managed
-    interpreter = ["bash", "-c"]
+output "hoop_connections" {
+  value = local.hoop_enabled ? {
+    "owner" = {
+      name           = "${local.db_identifier}-ow"
+      agent_id       = var.settings.hoop.agent_id
+      type           = "database"
+      subtype        = local.hoop_is_postgres ? "postgres" : "mysql"
+      tags           = try(var.settings.hoop.tags, {})
+      access_control = toset(try(var.settings.hoop.access_control, []))
+      access_modes   = { connect = "enabled", exec = "enabled", runbooks = "enabled", schema = "enabled" }
+      import         = try(var.settings.hoop.import, false)
+      secrets = local.hoop_is_postgres && local.hoop_is_managed ? {
+        "envvar:HOST"    = module.this.db_instance_address
+        "envvar:PORT"    = tostring(module.this.db_instance_port)
+        "envvar:USER"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_managed_secret_name}${local.hoop_secret_sep}username"
+        "envvar:PASS"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_managed_secret_name}${local.hoop_secret_sep}password"
+        "envvar:DB"      = local.db_name
+        "envvar:SSLMODE" = "prefer"
+        } : local.hoop_is_postgres && !local.hoop_is_managed ? {
+        "envvar:HOST"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}host"
+        "envvar:PORT"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}port"
+        "envvar:USER"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}username"
+        "envvar:PASS"    = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}password"
+        "envvar:DB"      = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}dbname"
+        "envvar:SSLMODE" = "prefer"
+        } : local.hoop_is_managed ? {
+        "envvar:HOST" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_managed_secret_name}${local.hoop_secret_sep}host"
+        "envvar:PORT" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_managed_secret_name}${local.hoop_secret_sep}port"
+        "envvar:USER" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_managed_secret_name}${local.hoop_secret_sep}username"
+        "envvar:PASS" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_managed_secret_name}${local.hoop_secret_sep}password"
+        "envvar:DB"   = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_managed_secret_name}${local.hoop_secret_sep}dbname"
+        } : {
+        "envvar:HOST" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}host"
+        "envvar:PORT" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}port"
+        "envvar:USER" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}username"
+        "envvar:PASS" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}password"
+        "envvar:DB"   = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${local.hoop_unmanaged_secret_name}${local.hoop_secret_sep}dbname"
+      }
+    }
+  } : null
+  precondition {
+    condition     = !local.hoop_enabled || try(var.settings.hoop.agent_id, "") != ""
+    error_message = "settings.hoop.agent_id must be set (as a Hoop agent UUID) when settings.hoop.enabled is true."
   }
-}
-
-output "hoop_connection_postgres_managed" {
-  value = local.hoop_connection_postgres_managed
-}
-
-resource "null_resource" "hoop_connection_postgres" {
-  count = local.hoop_connection_postgres != null && var.run_hoop ? 1 : 0
-  provisioner "local-exec" {
-    command     = local.hoop_connection_postgres
-    interpreter = ["bash", "-c"]
-  }
-}
-
-output "hoop_connection_postgres" {
-  value = local.hoop_connection_postgres
-}
-
-resource "null_resource" "hoop_connection_mysql_managed" {
-  count = local.hoop_connection_mysql_managed != null && var.run_hoop ? 1 : 0
-  provisioner "local-exec" {
-    command     = local.hoop_connection_mysql_managed
-    interpreter = ["bash", "-c"]
-  }
-}
-
-output "hoop_connection_mysql_managed" {
-  value = local.hoop_connection_mysql_managed
-}
-
-resource "null_resource" "hoop_connection_mysql" {
-  count = local.hoop_connection_mysql != null && var.run_hoop ? 1 : 0
-  provisioner "local-exec" {
-    command     = local.hoop_connection_mysql
-    interpreter = ["bash", "-c"]
-  }
-}
-
-output "hoop_connection_mysql" {
-  value = local.hoop_connection_mysql
 }

--- a/variables-rds.tf
+++ b/variables-rds.tf
@@ -68,10 +68,13 @@
 #   rotation_duration: "1h"            # (Optional) The duration of the lambda function to rotate the password, defaults to 1h
 #   iam:                               # (Optional) The IAM settings for the RDS instance
 #     database_authentication_enabled: true # (Optional) If true, the database authentication will be enabled, defaults to true
-#   hoop:                              # (Optional) The hoop settings for the RDS instance
+#   hoop:                              # (Optional) Hoop connection output settings for terraform-module-hoop-connection
 #     enabled: true                    # (Optional) If true, the hoop settings will be enabled, defaults to false
-#     agent: hoop-agent-name           # (Optional) The name of the hoop agent
-#     tags: ["tag1", "tag2"]           # (Optional) The tags for the hoop connection
+#     agent_id: "hoop-agent-uuid"      # (Required when enabled) Hoop agent UUID
+#     community: true                  # (Optional) Use community secret prefix (_aws:) vs enterprise (_envs/aws#); default: true
+#     import: false                    # (Optional) Import existing Hoop connection; default: false
+#     tags: {key: "value"}             # (Optional) Tags map for Hoop connection
+#     access_control: ["group"]        # (Optional) Access control groups for Hoop connection
 #   events:                            # (Optional) The events settings for the RDS instance
 #     enabled: true                    # (Optional) If true, the events settings will be enabled, defaults to false
 #     sns_topic_arn: "arn:aws:sns..."  # (Optional) The SNS topic ARN for the events
@@ -113,8 +116,3 @@ variable "security_groups" {
   default     = {}
 }
 
-variable "run_hoop" {
-  description = "Run hoop with agent, be careful with this option, it will run the HOOP command in output in a null_resource"
-  type        = bool
-  default     = false
-}


### PR DESCRIPTION
## Summary

- Replace old null_resource/local-exec hoop CLI pattern with a structured `hoop_connections` map output compatible with `terraform-module-hoop-connection`
- Remove `run_hoop` variable (breaking: callers must remove this input)
- Add `community` flag to select secret prefix: `_aws:` (community, default) or `_envs/aws#` (enterprise)
- Rename `settings.hoop.agent` → `settings.hoop.agent_id` (breaking)
- Add `settings.hoop.import` and `settings.hoop.access_control` support
- Add precondition: `agent_id` must be set when `hoop.enabled = true`
- Support postgresql managed/unmanaged and mysql engine types

+semver: breaking